### PR TITLE
react-native-scriptsをローカルにインストールし更新する

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "react-native-fetch": "^1.0.0",
     "react-native-maps": "^0.19.0",
     "react-native-navigation": "^1.1.377",
+    "react-native-scripts": "^1.11.1",
     "react-navigation": "^1.0.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
     "preset": "jest-expo"
   },
   "dependencies": {
-    "auth0-js": "^8.12.0",
     "expo": "^25.0.0",
     "install": "^0.10.4",
     "npm": "^4.2.0",


### PR DESCRIPTION
### パッケージの依存関係

```js
'react-native-scripts' // Create a React Native app on any OS with no build config.
  ├ 'xdl' // The Expo Development Library.
    ├ 'auth0-js@7.6.1'
```

auth0-jsはreact-native-scriptsの依存パッケージなので更新できませんでした。
react-native-scriptsは最新のバージョンです。
close #12 