### PR TITLE
CIで他のメンバが変更を確認できるようにする

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,14 @@
+machine:
+  node:
+    version: 6.9
+dependencies:
+  pre:
+    - npm install -g exp@48.0.4
+  test:
+    override:
+      - echo "no tests"
+deployment:
+  appr:
+    branch: /.*/
+    commands:
+      - 'if [ "$CI_PULL_REQUEST" != "" ]; then npm run appr; fi'

--- a/package.json
+++ b/package.json
@@ -3,9 +3,9 @@
   "version": "0.1.0",
   "private": true,
   "devDependencies": {
+    "react-native-scripts": "1.11.1",
     "appr": "^1.1.1",
     "jest-expo": "25.0.0",
-    "react-native-scripts": "1.11.1",
     "react-test-renderer": "16.2.0"
   },
   "main": "./node_modules/react-native-scripts/build/bin/crna-entry.js",

--- a/package.json
+++ b/package.json
@@ -3,8 +3,9 @@
   "version": "0.1.0",
   "private": true,
   "devDependencies": {
-    "react-native-scripts": "1.11.1",
+    "appr": "^1.1.1",
     "jest-expo": "25.0.0",
+    "react-native-scripts": "1.11.1",
     "react-test-renderer": "16.2.0"
   },
   "main": "./node_modules/react-native-scripts/build/bin/crna-entry.js",
@@ -13,7 +14,8 @@
     "eject": "react-native-scripts eject",
     "android": "react-native-scripts android",
     "ios": "react-native-scripts ios",
-    "test": "node node_modules/jest/bin/jest.js"
+    "test": "node node_modules/jest/bin/jest.js",
+    "appr": "appr"
   },
   "jest": {
     "preset": "jest-expo"


### PR DESCRIPTION
## 概要
パッケージapprを利用しコードがPushされたとき、CircleCIによって出力されたQRコードをExpoClientを用いて読み取ることで変更を実機で確認する

- パッケージapprのインストール
- CircleCIの設定

今回GitHubのトークンとエキスポのアカウントは自分の物を使用しました