### PR TITLE
get完了後にsplashscreenから画面遷移を行う

### DIFF
--- a/src/components/screens/HomeScreen.js
+++ b/src/components/screens/HomeScreen.js
@@ -2,9 +2,8 @@ import React, { Component } from 'react';
 import {
   StyleSheet,
   View,
-  ActivityIndicator
 } from 'react-native';
-
+import { AppLoading } from 'expo';
 import ListView from '../ListView';
 import PullRefresh from '../PullRefresh';
 import { getBooks } from '../../utils/Network';
@@ -79,9 +78,7 @@ export default class HomeScreen extends Component {
   render() {
     if (this.state.isLoading) {
       return (
-        <View style={styles.isLoading}>
-          <ActivityIndicator/>
-        </View>
+        <AppLoading/>
       );
     }
 

--- a/src/utils/Network.js
+++ b/src/utils/Network.js
@@ -32,7 +32,7 @@ export const getBooks = () => {
         }
         resolve(books);
       })
-      .catch((error) => console.error(error));
+      .catch((error) => reject(error));
   });
 };
 


### PR DESCRIPTION
## 概要
- APIからデータ取得後にSplashScreenからHomeScreenへ画面遷移を行う

## 技術的変更点
- expoのAppLoadingを利用する
- getBooksの修正
